### PR TITLE
DATA-1407: Import Dell GPG keys from local files after mirror switch

### DIFF
--- a/tasks/repo.yml
+++ b/tasks/repo.yml
@@ -36,7 +36,27 @@
     group: root
     mode: "0755"
 
-- name: Install GPG Keys
+- name: Install Dell GPG key files
   ansible.builtin.package:
     name: distribution-gpg-keys
     state: present
+
+# The GWDG mirror does not host Dell's pgp_pubkeys/, and distribution-gpg-keys
+# only drops the key files on disk without importing them. Import them into the
+# RPM keyring here so the gpgcheck-enabled Dell repos can verify packages
+# without depending on linux.dell.com being reachable at provision time.
+- name: Find Dell GPG key files
+  ansible.builtin.find:
+    paths: /usr/share/distribution-gpg-keys/dell
+    patterns:
+      - "*.asc"
+      - "*.key"
+  register: dell_gpg_key_files
+
+- name: Import Dell GPG keys
+  ansible.builtin.rpm_key:
+    key: "{{ item.path }}"
+    state: present
+  loop: "{{ dell_gpg_key_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DATA-1407
## Problem

Commit `9e71899` ("Use Dell repo mirror as Dell is down again") switched the repo to the GWDG mirror but removed **both** mechanisms that put Dell's signing keys into the RPM keyring — the `gpgkey:` URLs on the `yum_repository` tasks and the explicit `rpm_key` import — while leaving `gpgcheck: true` in place.

`distribution-gpg-keys` only drops key **files** on disk (`/usr/share/distribution-gpg-keys/dell/*.asc`); it never runs `rpm --import`. The GWDG mirror doesn't host Dell's pubkeys either. Net effect on any host provisioned after `9e71899` without a pre-existing Dell key:

```
Public key for dell-system-update-*.rpm is not installed
Error: GPG check FAILED
```

Existing fleet hosts were immune because a `gpg-pubkey` stays in the rpmdb once imported; only freshly-racked hosts (the DATA-1338 `chk*`/`ch*` ramp-up) hit it.

## Fix

Re-add an explicit import, but from the **local** `distribution-gpg-keys` files instead of the network:

- `find` runs on the **managed host** — a `fileglob` lookup would glob the Ansible controller, silently matching nothing.
- Globbing `*.asc`/`*.key` (rather than a hardcoded list) means future Dell key rotations shipped by the package are picked up automatically. This also covers Dell's newer non-`0x`-prefixed naming (e.g. the 2024 `support@dell.com` key `3022882DE02EE5CC.asc`), which a `0x*.asc` glob would miss.
- `gpgcheck: true` stays on — verification is **not** disabled.

## Verification

Tested end-to-end against the real broken host `chk01.dw2.rmge.net` (0 Dell keys, `gpgcheck=1`, no `gpgkey`):

- Role converges; `Update dell-system-update` (previously "GPG check FAILED") now succeeds.
- 7 Dell keys imported into the rpmdb, including the signing key `1285491434D8786F`.
- `dnf reinstall -y dell-system-update` → `Complete!` with gpgcheck on.
- Re-runs are idempotent (import + update report `ok`).
- ansible-lint (production profile) + full pre-commit pass.

## Notes / follow-ups

- Already-broken hosts provisioned before this fix need the fixed role re-run (or a one-off `rpm --import`); merging alone doesn't retroactively import keys.
- Rollout: cut a new `remerge.dell` release and bump the pin in `dw-cluster/.ansible/requirements.yaml`.
- A separate, **pre-existing** idempotency bug in `ism.yml` (`Extract Dell Systems-Management Application` fails on re-run) was observed during testing — unrelated to GPG, to be handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)