### PR TITLE
DATA-1407: Make Dell iSM extract/install idempotent

### DIFF
--- a/tasks/ism.yml
+++ b/tasks/ism.yml
@@ -3,22 +3,34 @@
   ansible.builtin.dnf:
     name: "Systems-Management_Application_{{ systems_management_version }}"
     state: present
+  register: dell_ism_dup
 
-- name: Extract Dell Systems-Management Application
-  ansible.builtin.command:
-    cmd: "/usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}.BIN --extract Systems-Management_Application_{{ systems_management_version }}"
-    chdir: /usr/libexec/dell_dup
-    creates: /usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}
+# The DUP's self-extracting .BIN (and the whole /usr/libexec/dell_dup tree it
+# owns) is removed once the packages have been extracted and installed, yet the
+# DUP RPM stays registered as installed -- so dnf will not restore the .BIN on a
+# re-run. Only extract and install the inner RPMs when the DUP RPM was actually
+# just (re)installed, which is the only moment the .BIN exists on disk. This is
+# idempotent for the three real states: fresh install (changed), unchanged
+# re-run (skipped), and version bump (new package name -> changed). A handler is
+# unsuitable here because these steps must run in sequence, mid-play.
+- name: Extract and install Dell iSM from the freshly installed DUP # noqa: no-handler
+  when: dell_ism_dup is changed
+  block:
+    - name: Extract Dell Systems-Management Application
+      ansible.builtin.command:
+        cmd: "/usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}.BIN --extract Systems-Management_Application_{{ systems_management_version }}"
+        chdir: /usr/libexec/dell_dup
+        creates: /usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}
 
-- name: Install dcism-osc RPM package
-  ansible.builtin.dnf:
-    name: /usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}/dcism-osc-{{ dcism_osc_version }}.rpm
-    state: present
+    - name: Install dcism-osc RPM package
+      ansible.builtin.dnf:
+        name: /usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}/dcism-osc-{{ dcism_osc_version }}.rpm
+        state: present
 
-- name: Install dcism RPM package
-  ansible.builtin.dnf:
-    name: /usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}/dcism-{{ dcism_version }}.el9.x86_64.rpm
-    state: present
+    - name: Install dcism RPM package
+      ansible.builtin.dnf:
+        name: /usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}/dcism-{{ dcism_version }}.el9.x86_64.rpm
+        state: present
 
 - name: Start iDRAC Service Module
   ansible.builtin.systemd:


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DATA-1407
## Problem

On any second convergence of the role, `ism.yml`'s `Extract Dell Systems-Management Application` task fails:

```
Error executing command: [Errno 2] No such file or directory:
  b'/usr/libexec/dell_dup/Systems-Management_Application_..._A00_02.BIN'
```

### Root cause

The `Systems-Management_Application_*` DUP RPM ships a self-extracting `.BIN` under `/usr/libexec/dell_dup/`. After the inner `dcism`/`dcism-osc` RPMs are extracted and installed, that whole directory — **including the RPM-owned `.BIN`** — is deleted, while the DUP RPM stays registered as installed. Verified on the host:

- `rpm -q Systems-Management_Application_…` → installed; owns `…/*.BIN`
- `/usr/libexec/dell_dup/` → **does not exist**
- `dnf install <DUP>` → **"Nothing to do"** (dnf won't restore the deleted `.BIN`)

So on re-run: the `Extract` command runs (its `creates:` dir is also gone) and fails on the missing `.BIN`; the two `dcism*` installs (absolute paths into the same deleted tree) would fail the same way.

## Fix

Gate the `.BIN`-dependent steps (extract + both inner RPM installs) on the DUP RPM having **actually just been (re)installed** — `register` + `when: dell_ism_dup is changed` — the only moment the `.BIN` exists on disk. Idempotent across the three real states:

| State | DUP dnf result | Behavior |
|-------|----------------|----------|
| Fresh install | changed | extract + install run |
| Unchanged re-run | ok | **skipped** (was the bug) |
| Version bump (new package name) | changed | extract + install run |

Wrapped in a `block` with `# noqa: no-handler` — a handler is unsuitable because these steps must run in sequence, mid-play.

## Verification

Tested on `chk01.dw2.rmge.net`, which was in the exact failing state (DUP registered, `.BIN` deleted, `dcism` installed):

```
chk01.dw2.rmge.net : ok=15  changed=0  unreachable=0  failed=0  skipped=3
```

Two consecutive runs converge clean; the three `.BIN`-dependent tasks skip. Fresh-install behavior is unchanged by construction (when the DUP is genuinely (re)installed, the gate is true). ansible-lint (production profile) + pre-commit pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)