### PR TITLE
DATA-1407: Set up dsu (packages + public keys) in dsu.yml before ism

### DIFF
--- a/tasks/dsu.yml
+++ b/tasks/dsu.yml
@@ -1,0 +1,36 @@
+---
+# The dsu tool (Dell System Update) verifies the catalogs it downloads against
+# Dell's public keys, which it reads as files from its working directory
+# /usr/libexec/dell_dup (the path is compiled into the binary; `dsu
+# --import-public-key` reads the 0x*.asc files there). Stage them from the local
+# distribution-gpg-keys package so verification succeeds without reaching
+# linux.dell.com (down) or the GWDG mirror (does not host the pubkeys).
+#
+# This must run *after* "Update dell-system-update": upgrading that package runs
+# `rm -rf /usr/libexec/dell_dup` in its RPM scriptlet, which would otherwise wipe
+# freshly staged keys.
+- name: Ensure Dell DUP working directory exists
+  ansible.builtin.file:
+    path: /usr/libexec/dell_dup
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Find Dell public key files
+  ansible.builtin.find:
+    paths: /usr/share/distribution-gpg-keys/dell
+    patterns: "0x*.asc"
+  register: dell_dsu_key_files
+
+- name: Stage Dell public keys for dsu signature verification
+  ansible.builtin.copy:
+    src: "{{ item.path }}"
+    dest: "/usr/libexec/dell_dup/{{ item.path | basename }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0644"
+  loop: "{{ dell_dsu_key_files.files }}"
+  loop_control:
+    label: "{{ item.path | basename }}"

--- a/tasks/dsu.yml
+++ b/tasks/dsu.yml
@@ -1,14 +1,23 @@
 ---
-# The dsu tool (Dell System Update) verifies the catalogs it downloads against
-# Dell's public keys, which it reads as files from its working directory
-# /usr/libexec/dell_dup (the path is compiled into the binary; `dsu
-# --import-public-key` reads the 0x*.asc files there). Stage them from the local
-# distribution-gpg-keys package so verification succeeds without reaching
-# linux.dell.com (down) or the GWDG mirror (does not host the pubkeys).
+# Install the Dell System Update packages and stage the public keys dsu needs.
 #
-# This must run *after* "Update dell-system-update": upgrading that package runs
-# `rm -rf /usr/libexec/dell_dup` in its RPM scriptlet, which would otherwise wipe
-# freshly staged keys.
+# `dsu --import-public-key` reads Dell's public keys as *files* from its working
+# directory /usr/libexec/dell_dup (the path is compiled into the binary) and uses
+# them to verify the catalogs it downloads. Neither linux.dell.com (down) nor the
+# GWDG mirror serves these pubkeys, so stage them from the local
+# distribution-gpg-keys package.
+#
+# Ordering matters: upgrading dell-system-update runs `rm -rf /usr/libexec/dell_dup`
+# in its RPM scriptlet, so the keys are staged *after* that upgrade, here in this
+# file, and this file runs before ism.yml.
+- name: Update dell-system-update
+  ansible.builtin.dnf:
+    state: latest # noqa package-latest
+    name:
+      - dell-system-update
+      - dsucatalog
+      - srvadmin-idracadm7
+
 - name: Ensure Dell DUP working directory exists
   ansible.builtin.file:
     path: /usr/libexec/dell_dup

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,5 +13,8 @@
 - name: Import ism.yml
   ansible.builtin.import_tasks: ism.yml
 
+- name: Import dsu.yml
+  ansible.builtin.import_tasks: dsu.yml
+
 - name: Import perccli.yml
   ansible.builtin.import_tasks: perccli.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,19 +2,11 @@
 - name: Import repo.yml
   ansible.builtin.import_tasks: repo.yml
 
-- name: Update dell-system-update
-  ansible.builtin.dnf:
-    state: latest # noqa package-latest
-    name:
-      - dell-system-update
-      - dsucatalog
-      - srvadmin-idracadm7
+- name: Import dsu.yml
+  ansible.builtin.import_tasks: dsu.yml
 
 - name: Import ism.yml
   ansible.builtin.import_tasks: ism.yml
-
-- name: Import dsu.yml
-  ansible.builtin.import_tasks: dsu.yml
 
 - name: Import perccli.yml
   ansible.builtin.import_tasks: perccli.yml


### PR DESCRIPTION
## Problem

Importing Dell's keys into the RPM keyring (PR #30) fixed `dnf`, but the `dsu` tool itself was still broken:

```
$ dsu --non-interactive --import-public-key --preview
Unable to read public file /usr/libexec/dell_dup/0x756ba70b1019ced6.asc
... (all six)
Importing public key(s) failed
Signature verification failed for CatalogIndex.gz
Exiting DSU!
```

### Root cause

`dsu --import-public-key` reads Dell's public keys as **files** from its working directory `/usr/libexec/dell_dup` (hardcoded in the binary), imports them, and uses them to verify the `CatalogIndex.gz` it downloads. With the files absent, the import fails and catalog verification fails.

The pre-`9e71899` role staged these files via `get_url` from `linux.dell.com`; that task was removed. Neither `linux.dell.com` (down) nor the GWDG mirror serves the pubkeys — but `distribution-gpg-keys` already ships them locally.

### Why ordering matters

`dell-system-update`'s RPM scriptlet runs `rm -rf /usr/libexec/dell_dup` on upgrade. So whenever `Update dell-system-update` (`state: latest`) upgrades DSU, that directory is wiped (also the mechanism behind the iSM `.BIN` idempotency bug in #31). The keys must therefore be staged **after** that upgrade.

## Change

New `tasks/dsu.yml` that owns the full Dell System Update setup, imported **before** `ism.yml`:

1. `Update dell-system-update` — moved here from `main.yml` (so the upgrade's `rm -rf` happens first).
2. Ensure `/usr/libexec/dell_dup` exists.
3. `find` the six `0x*.asc` Dell keys from `distribution-gpg-keys`.
4. Copy them into `/usr/libexec/dell_dup/` (idempotent `copy`, `remote_src`).

`main.yml` is now just the ordered imports: `repo → dsu → ism → perccli`.

## Verification (chk01.dw2.rmge.net)

- **DUP already installed** (fleet norm), after `rm -rf /usr/libexec/dell_dup`: role converges `failed=0`, iSM block skipped, keys restaged; `dsu … --preview` exits **0**, verifies the catalog, lists updates. Re-run idempotent (`changed=0`).
- **DUP removed** (fresh path): keys are staged before `ism.yml` reinstalls + extracts the DUP; the staged keys **survive** the extract; role `failed=0`; `dsu … --preview` exits **0**, no signature failure.
- ansible-lint (production profile) + pre-commit pass.

## Dependency / rollout

Complements #30 (dnf keyring) and #31 (iSM idempotency); all three land the full fix. Ships to the fleet via a new `remerge.dell` release + the `requirements.yaml` pin bump in `dw-cluster`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)