### PR TITLE
DATA-1407: Bump Dell repo to DSU_26.06.22 and iSM to 6.1.0.0

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,12 +1,15 @@
 ---
 # https://linux.dell.com/repo/hardware/
 dell_repo_base_url: "https://ftp.gwdg.de/pub/linux/dell/repo"
-dell_repo_version: "DSU_25.11.24"
+dell_repo_version: "DSU_26.06.22"
 
 # https://linux.dell.com/repo/hardware/dsu/os_independent/noarch/
-systems_management_version: "J9FG1_LN64_5.4.2.0_A00_02"
-dcism_osc_version: "7.4.2.0-221"
-dcism_version: "5.4.2.0-4005"
+# systems_management_version is the OpenManage / iDRAC Service Module DUP; the
+# dcism* versions are the RPMs it extracts (dcism-<dcism_version>.el9.x86_64.rpm
+# and dcism-osc-<dcism_osc_version>.rpm).
+systems_management_version: "238XW_LN64_6.1.0.0_A01"
+dcism_osc_version: "8.1.0.0-228"
+dcism_version: "6.1.0.0-4104"
 
 # https://www.dell.com/support/search/en-us?lwp=rt#q=linux%20perccli%20utility&sort=date%20descending&f:iuxType=[Drivers%20%26%20Downloads]&f:langFacet=[en]
 perccli_rpm: "perccli-007.3208.0000.0000-1.noarch.rpm"


### PR DESCRIPTION
https://remerge.atlassian.net/browse/DATA-1407
## What

Update the pinned Dell package versions in `vars/main.yml` to the current release.

| Var | Before | After |
|-----|--------|-------|
| `dell_repo_version` | `DSU_25.11.24` | `DSU_26.06.22` |
| `systems_management_version` | `J9FG1_LN64_5.4.2.0_A00_02` | `238XW_LN64_6.1.0.0_A01` |
| `dcism_version` | `5.4.2.0-4005` | `6.1.0.0-4104` |
| `dcism_osc_version` | `7.4.2.0-221` | `8.1.0.0-228` |

## How the values were determined (authoritative, not guessed)

- **`DSU_26.06.22`** is the newest snapshot under `https://ftp.gwdg.de/pub/linux/dell/repo/hardware/`. The old `DSU_25.11.24` topped out at iSM 6.0.5.0 and did not contain the 6.1.0.0 DUP, so the repo had to move to get it.
- **`238XW_LN64_6.1.0.0_A01`** is OpenManage / iDRAC Service Module 6.1.0.0 — the version `dsu`'s catalog now recommends — present as `Systems-Management_Application_238XW_LN64_6.1.0.0_A01-6.1.0.0-26.06.22.x86_64.rpm` in `DSU_26.06.22`.
- **`dcism` / `dcism-osc`** versions were read from the RPMs that 6.1.0.0 DUP extracts: `dcism-6.1.0.0-4104.el9.x86_64.rpm` and `dcism-osc-8.1.0.0-228.rpm`.

`dsucatalog` and `dell-system-update` track the repo automatically (`state: latest`).

## Not changed: perccli

`perccli` is a separate `dl.dell.com` download pinned by a FOLDER-id URL **and** sha256 checksum — neither derivable from the DSU repo, and a guessed checksum would break the download. Left as-is; happy to bump it separately given the new URL + checksum.

## Verification (chk01.dw2.rmge.net)

Role converges `failed=0` and installs:

```
Systems-Management_Application_238XW_LN64_6.1.0.0_A01-6.1.0.0-26.06.22
dcism-6.1.0.0-4104.el9.x86_64
dcism-osc-8.1.0.0-228.x86_64
dsucatalog-26.06.22-4GGCN.noarch
```

`dcismeng` active; `dsu --preview` exits 0 against the `DSU_26.06.22` repo, no signature failure.

> Note: end-to-end `dsu` verification also relies on #32 (which stages the DSU pubkeys). This PR is the version data only; apply alongside #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)