### PR TITLE
Force iSM to use IPv4 for OS-BMC USB NIC passthrough (CORE-2123)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,1 +1,9 @@
 ---
+# Force the iDRAC Service Module to use IPv4 for the OS-to-iDRAC USB NIC
+# passthrough. On newer iDRAC firmware iSM defaults to connecting over IPv6
+# link-local and then never runs its host-side setup script, so the OS never
+# gets the 169.254.x.x IPv4 on the `idrac` interface. Anything that scrapes the
+# iDRAC over the USB NIC (e.g. idrac-exporter -> idrac.local) then breaks after
+# a reboot until the IP is added by hand. Forcing IPv4 makes iSM assign the
+# host-side address automatically again. See CORE-2123.
+dell_ism_force_ipv4: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,3 +3,8 @@
   ansible.builtin.command:
     cmd: update-ca-trust
   changed_when: true
+
+- name: Restart iDRAC Service Module
+  ansible.builtin.systemd:
+    name: dcismeng
+    state: restarted

--- a/tasks/ism.yml
+++ b/tasks/ism.yml
@@ -32,6 +32,14 @@
         name: /usr/libexec/dell_dup/Systems-Management_Application_{{ systems_management_version }}/dcism-{{ dcism_version }}.el9.x86_64.rpm
         state: present
 
+- name: Force iSM to use IPv4 for the OS-BMC USB NIC passthrough (CORE-2123)
+  ansible.builtin.lineinfile:
+    path: /opt/dell/srvadmin/iSM/etc/ini/dcismdy64.ini
+    regexp: '^IPV6\s*='
+    line: "IPV6={{ 'FALSE' if dell_ism_force_ipv4 else 'TRUE' }}"
+    state: present
+  notify: Restart iDRAC Service Module
+
 - name: Start iDRAC Service Module
   ansible.builtin.systemd:
     name: dcismeng


### PR DESCRIPTION
## Problem

After a reboot, Dell hosts come up with **no IPv4 on the `idrac` USB pass-through NIC**, only the kernel's IPv6 link-local. Anything scraping the iDRAC over that link (idrac-exporter → `idrac.local` = `169.254.1.1`) then fails with `MetricsEndpointNotResponding` until someone runs `ip addr add 169.254.1.2/16 dev idrac` by hand. See [CORE-2123](https://remerge.atlassian.net/browse/CORE-2123).

## Root cause

The host-side IPv4 is normally assigned automatically by iSM (`dcismeng`) via its own script `dcism-setup_usbintf.sh` — but **only when iSM connects to the iDRAC over IPv4**. On newer iDRAC firmware (observed on 7.20), iSM's dynamic config `dcismdy64.ini` carries `[Network Protocol Version] IPV6=TRUE`, so iSM connects over IPv6 link-local (`fe80::`, always present) and never triggers the IPv4 host-side setup. Confirmed on `drn24.dw2.rmge.net`: working hosts' iSM logs `connected … using IPv4 protocol`; broken hosts log `… IPv6 protocol`.

## Fix

Set `IPV6=FALSE` in `dcismdy64.ini` and restart `dcismeng`. iSM then connects over IPv4 and assigns the host-side `169.254.1.2/16` automatically again. Verified on drn24: after the change + restart, iSM switched to `IPv4 protocol`, the address appeared on its own (~80s after start), and the exporter returned HTTP 200.

Gated by a new `dell_ism_force_ipv4` default (`true`).

### Notes

- `lineinfile` (not `ini_file`) is used deliberately — a surgical single-line replace matching what was verified against iSM's parser; there is exactly one `IPV6=` key in the file.
- Applying this to already-running hosts restarts `dcismeng` (management-plane only, no data-path impact) and clears the condition **without a reboot**, while also making it survive future reboots.

## Test plan

- [x] `IPV6=FALSE` + `dcismeng` restart auto-assigns `169.254.1.2`, exporter HTTP 200 (drn24, via `systemctl restart`)
- [ ] Confirm it survives a real reboot of a Dell host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CORE-2123]: https://remerge.atlassian.net/browse/CORE-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ